### PR TITLE
URL Cleanup

### DIFF
--- a/spring-solr-repository-example/pom.xml
+++ b/spring-solr-repository-example/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>spring-solr-repository-example</artifactId>
   <version>1.0.0.BUILD-SNAPSHOT</version>
   <inceptionYear>2012</inceptionYear>
-  <url>http://github.com/SpringSource/spring-data-solr-examples</url>
+  <url>https://github.com/SpringSource/spring-data-solr-examples</url>
   <name>Spring Data Solr Example</name>
 
   <properties>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
       <comments>
         Copyright 2010 the original author or authors.
@@ -28,7 +28,7 @@
         you may not use this file except in compliance with the License.
         You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,
@@ -139,7 +139,7 @@
   <repositories>
     <repository>
       <id>spring-snapshots</id>
-      <url>http://repo.springsource.org/libs-snapshot</url>
+      <url>https://repo.springsource.org/libs-snapshot</url>
     </repository>
   </repositories>
 </project>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://github.com/SpringSource/spring-data-solr-examples migrated to:  
  https://github.com/SpringSource/spring-data-solr-examples ([https](https://github.com/SpringSource/spring-data-solr-examples) result 301).
* http://repo.springsource.org/libs-snapshot migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance