### PR TITLE
URL Cleanup

### DIFF
--- a/spring-solr-repository-example/README
+++ b/spring-solr-repository-example/README
@@ -1,13 +1,13 @@
 #################################################################################
 #                                                                               # 
 #    In order to run this example a solr 4.1 server has to be available.        #            
-#    You may download it from the solr website http://lucene.apache.org/solr    #
+#    You may download it from the solr website https://lucene.apache.org/solr    #
 #                                                                               #
 ################################################################################# 
    
 ### Installing Solr  ####
 1. Get solr
-   download: http://www.apache.org/dyn/closer.cgi/lucene/solr/4.1.0
+   download: https://www.apache.org/dyn/closer.cgi/lucene/solr/4.1.0
    
 2. Start solr server
    extract: unarchive to destination directory


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/dyn/closer.cgi/lucene/solr/4.1.0 with 1 occurrences migrated to:  
  https://www.apache.org/dyn/closer.cgi/lucene/solr/4.1.0 ([https](https://www.apache.org/dyn/closer.cgi/lucene/solr/4.1.0) result 200).
* [ ] http://lucene.apache.org/solr with 1 occurrences migrated to:  
  https://lucene.apache.org/solr ([https](https://lucene.apache.org/solr) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8983/solr with 1 occurrences
* http://localhost:8983/solr/ with 1 occurrences